### PR TITLE
Fix invalid Prop

### DIFF
--- a/src/components/Blueprint.vue
+++ b/src/components/Blueprint.vue
@@ -2,7 +2,7 @@
   <component
     :is="component"
     v-bind="$attrs"
-    draggable="true"
+    :draggable="true"
     @dragstart="handleDragStart"
     @dragend="handleDragEnd"
     @dragstart.native="handleDragStart"


### PR DESCRIPTION
Using `v-chip` as a component to drag, a string `true` is passed down to said component, where it expects a boolean prop.

Check images below

![image](https://user-images.githubusercontent.com/26031459/114295830-95e19a80-9a9f-11eb-8581-c933c1221abb.png)

![image](https://user-images.githubusercontent.com/26031459/114295806-6d59a080-9a9f-11eb-9402-4863df9d5d02.png)
